### PR TITLE
Fix fast_stable_diffusion_AUTOMATIC1111.ipynb add  "torchsde"

### DIFF
--- a/fast_stable_diffusion_AUTOMATIC1111.ipynb
+++ b/fast_stable_diffusion_AUTOMATIC1111.ipynb
@@ -336,6 +336,7 @@
         "  !pip install -q tensorflow tensorflow-io\n",
         "  !pip install -q git+https://github.com/KichangKim/DeepDanbooru.git@edf73df4cdaeea2cf00e9ac08bd8a9026b7a7b26#egg=deepdanbooru\n",
         "  !pip install -q inflection\n",
+        "  !pip install -q torchsde\n",
         "\n",
         "  if os.path.exists('/content/gdrive/MyDrive/sd/stable-diffusion-webui/extensions/deforum-for-automatic1111-webui/scripts/deforum/src/infer.py'):\n",
         "    %cd /content/gdrive/MyDrive/sd/stable-diffusion-webui/extensions/deforum-for-automatic1111-webui/scripts/deforum_helpers\n",


### PR DESCRIPTION
added `!pip install -q torchsde` to fix error is giving right now when trying to start webui

Traceback (most recent call last):
  File "/content/gdrive/MyDrive/sd/stable-diffusion-webui/webui.py", line 13, in <module>
    from modules import devices, sd_samplers, upscaler, extensions, localization
  File "/content/gdrive/Shareddrives/unlimitedPower/sd/stable-diffusion-webui/modules/sd_samplers.py", line 8, in <module>
    import k_diffusion.sampling
  File "/content/gdrive/MyDrive/sd/stable-diffusion/src/k-diffusion/k_diffusion/__init__.py", line 1, in <module>
    from . import augmentation, config, evaluation, external, gns, layers, models, sampling, utils
  File "/content/gdrive/MyDrive/sd/stable-diffusion/src/k-diffusion/k_diffusion/external.py", line 6, in <module>
    from . import sampling, utils
  File "/content/gdrive/MyDrive/sd/stable-diffusion/src/k-diffusion/k_diffusion/sampling.py", line 7, in <module>
    import torchsde
ModuleNotFoundError: No module named 'torchsde'