### PR TITLE
Add stable-diffusion tag to dreambooth colab

### DIFF
--- a/fast-DreamBooth.ipynb
+++ b/fast-DreamBooth.ipynb
@@ -1203,6 +1203,7 @@
         "license: creativeml-openrail-m\n",
         "tags:\n",
         "- text-to-image\n",
+        "- stable-diffusion\n",
         "---\n",
         "### {name_of_your_concept} Dreambooth model trained by {api.whoami(token=hf_token)[\"name\"]} with [TheLastBen's fast-DreamBooth](https://colab.research.google.com/github/TheLastBen/fast-stable-diffusion/blob/main/fast-DreamBooth.ipynb) notebook\n",
         "\n",


### PR DESCRIPTION
Important to have the correct pipeline for SD in the API inference and avoid this kind of error:

![image](https://user-images.githubusercontent.com/29777165/203151140-8204626c-bff4-42a8-b112-a68b06e7de6e.png)
