### PR TITLE
Ngrok tunneling and authentication support

### DIFF
--- a/fast_stable_diffusion_AUTOMATIC1111.ipynb
+++ b/fast_stable_diffusion_AUTOMATIC1111.ipynb
@@ -30,7 +30,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "CFWtw-6EPrKi"
@@ -277,7 +277,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "ZGV_5H4xrOSp"
@@ -390,8 +390,17 @@
         "import sys\n",
         "import fileinput\n",
         "\n",
+        "\n",
+        "Tunneling_Provider = \"localtunnel\" #@param [\"localtunnel\", \"ngrok\"]\n",
+        "#@markdown  - fill the below if you choose ngrok\n",
+        "\n",
+        "ngrok_auth_token = \"auth_token:webui_user:webui_pwd\" #@param {type:\"string\"}\n",
+        "ngrok_region = \"us\" #@param [\"us\", \"eu\", \"ap\", \"au\", \"sa\", \"jp\", \"in\"]\n",
+        "#@markdown  - ngrok: recommended you manually enforce HTTPS, until this [webui PR](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/4583/files) is approved, make the same edits in your own file. Make the edit and check the below:\n",
+        "ngrok_did_manually_edit_https = False #@param {type:\"boolean\"}\n",
         "Use_Gradio_Server = False #@param {type:\"boolean\"}\n",
         "#@markdown  - Only if you have trouble connecting to the local server\n",
+        "\n",
         "\n",
         "Hypernetwork_Compatibility = False #@param {type:\"boolean\"}\n",
         "\n",
@@ -410,10 +419,6 @@
         "    %cd /content/gdrive/MyDrive/sd/stable-diffusion-webui/ldm/modules\n",
         "    !wget -O attention.py https://raw.githubusercontent.com/TheLastBen/fast-stable-diffusion/main/precompiled/attention.py\n",
         "    \n",
-        "  \n",
-        "with capture.capture_output() as cap: \n",
-        "  if not os.path.exists('/tools/node/bin/lt'):\n",
-        "    !npm install -g localtunnel\n",
         "\n",
         "with capture.capture_output() as cap: \n",
         "  %cd /content/gdrive/MyDrive/sd/stable-diffusion-webui/\n",
@@ -428,7 +433,14 @@
         "  !sed -i 's@min-height: 4.*@min-height: 5.5em;@g' /content/gdrive/MyDrive/sd/stable-diffusion-webui/style.css  \n",
         "  %cd /content\n",
         "\n",
+        "with capture.capture_output() as cap: \n",
+        "  if not Use_Gradio_Server:\n",
+        "    if Tunneling_Provider == 'localtunnel' and not os.path.exists('/tools/node/bin/lt'):\n",
+        "      !npm install -g localtunnel\n",
+        "    if Tunneling_Provider == 'ngrok' and not os.path.exists('/usr/local/bin/ngrok'):\n",
+        "      !pip install pyngrok\n",
         "\n",
+        "ngrok=''\n",
         "share=''\n",
         "if Use_Gradio_Server:\n",
         "  share='--share'\n",
@@ -439,6 +451,20 @@
         "        line = '            self.server_port = server_port\\n'\n",
         "    sys.stdout.write(line)\n",
         "  clear_output()\n",
+        "\n",
+        "elif Tunneling_Provider == \"ngrok\":\n",
+        "  share = ''\n",
+        "  ngrok = f'--ngrok \"{ngrok_auth_token}\" --ngrok-region \"{ngrok_region}\"'\n",
+        "  for line in fileinput.input('/usr/local/lib/python3.7/dist-packages/gradio/blocks.py', inplace=True):\n",
+        "    if line.strip().startswith('self.server_name ='):\n",
+        "        line = '            self.server_name = server_name\\n'\n",
+        "    if line.strip().startswith('self.server_port ='):\n",
+        "        line = f'            self.server_port = \"{\"443\" if manually_set_ngrok_https else \"server_port\"}\" \\n'\n",
+        "    if line.strip().startswith('if self.local_url.startswith(\"https\") or self.is_colab') and manually_set_ngrok_https:\n",
+        "        line = ''    \n",
+        "    if line.strip().startswith('else \"http\"') and manually_set_ngrok_https:\n",
+        "        line = ''  \n",
+        "    sys.stdout.write(line)\n",
         "  \n",
         "else:\n",
         "  share=''\n",
@@ -474,18 +500,17 @@
         "try:\n",
         "  model\n",
         "  if os.path.isfile(model):\n",
-        "    !python /content/gdrive/MyDrive/sd/stable-diffusion-webui/webui.py $share $api --disable-safe-unpickle --no-half-vae  --ckpt \"$model\"\n",
+        "    !python /content/gdrive/MyDrive/sd/stable-diffusion-webui/webui.py $share $ngrok $api --disable-safe-unpickle --no-half-vae  --ckpt \"$model\"\n",
         "  else:\n",
-        "    !python /content/gdrive/MyDrive/sd/stable-diffusion-webui/webui.py $share $api --disable-safe-unpickle --no-half-vae  --ckpt-dir \"$model\"\n",
+        "    !python /content/gdrive/MyDrive/sd/stable-diffusion-webui/webui.py $share $ngrok $api --disable-safe-unpickle --no-half-vae  --ckpt-dir \"$model\"\n",
         "except:\n",
-        "   !python /content/gdrive/MyDrive/sd/stable-diffusion-webui/webui.py $share $api --disable-safe-unpickle --no-half-vae "
+        "   !python /content/gdrive/MyDrive/sd/stable-diffusion-webui/webui.py $share $ngrok $api --disable-safe-unpickle --no-half-vae "
       ]
     }
   ],
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
       "provenance": []
     },
     "kernelspec": {


### PR DESCRIPTION
The `localtunnel` approach remains default, however it's not clear how secure it is. Users must trust a 3rd party in any case, and use a publicly accessible URL,  however there should be more optionality. 

This simple PR adds an alternative approach for tunneling, specifically ngrok since the webui repo supports it.

This allows users to setup a private/secure tunnel, with additional benefit of creating a temporary webui user name and password.

