### PR TITLE
Enable switch between checkpoint copies in webui

### DIFF
--- a/fast-DreamBooth.ipynb
+++ b/fast-DreamBooth.ipynb
@@ -1018,6 +1018,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "cellView": "form",
         "id": "iAZGngFcI8hq"
       },
       "outputs": [],


### PR DESCRIPTION
Set ckpt-dir so that user can switch between checkpoint copies using webui.

Also colab removed trailing white spaces.