### PR TITLE
Dreambooth fix (check_output)

### DIFF
--- a/fast-DreamBooth.ipynb
+++ b/fast-DreamBooth.ipynb
@@ -373,6 +373,7 @@
         "from IPython.utils import capture\n",
         "from os import listdir\n",
         "from os.path import isfile\n",
+        "from subprocess import check_output\n",
         "import wget\n",
         "import time\n",
         "\n",


### PR DESCRIPTION
NameError Traceback (most recent call last)
in <cell line: 92>()
101 wget.download('https://github.com/TheLastBen/fast-stable-diffusion/raw/main/Dreambooth/det.py')
102 print('Detecting model version...')
--> 103 Model_Version=check_output('python det.py --MODEL_PATH '+MDLPTH, shell=True).decode('utf-8').replace('\n', '')
104 clear_output()
105 print(''+Model_Version+' Detected')

NameError: name 'check_output' is not defined